### PR TITLE
fix test for upcoming units 0.8-6

### DIFF
--- a/tests/testthat/test-long_to_wide.R
+++ b/tests/testthat/test-long_to_wide.R
@@ -6,7 +6,7 @@ df <- data.frame(pollutant = rep(c("CO", "propadiene", "NO2"), 10),
 
 data(net)
 test_that("long_to_wide works", {
-  expect_equal(long_to_wide(df)$CO[1],
+  expect_equal(as.numeric(long_to_wide(df)$CO[1]),
                1)
 })
 


### PR DESCRIPTION
Dear maintainer,

We are preparing units 0.8-6 for release. I'm writing to you because our revdep checks report new issues in your package with this new version (you can check them [here](https://github.com/r-quantities/units/blob/main/revdep/problems.md#vein)).

These issues are caused by the recent addition of the `cbind.units` and `rbind.units` methods. Thanks to this, your `long_to_wide()` function now preserves units, and therefore, a test needed to be adjusted for this fact.

We would appreciate if you could merge this patch and send an update to CRAN as time permits.